### PR TITLE
Handle duplicated rows in preprocess.data_matrix.k_nearest_neighbors

### DIFF
--- a/pymde/preprocess/data_matrix.py
+++ b/pymde/preprocess/data_matrix.py
@@ -154,6 +154,18 @@ def k_nearest_neighbors(data, k, max_distance=None, verbose=False):
         [edges[flip_idx][:, 1], edges[flip_idx][:, 0]], axis=1
     )
 
+    duplicated_edges_mask = edges[:, 0] == edges[:, 1]
+    if duplicated_edges_mask.any():
+        problem.LOGGER.warning(
+            "Your dataset appears to contain duplicated items (rows); "
+            "when embedding, you should typically have unique items."
+        )
+        problem.LOGGER.warning(
+            "The following items have duplicates "
+            f"{edges[duplicated_edges_mask][:, 0]}"
+        )
+        edges = edges[~duplicated_edges_mask]
+
     weights = torch.ones(edges.shape[0], device=device, dtype=torch.float)
     if max_distance is not None:
         weights[

--- a/pymde/recipes.py
+++ b/pymde/recipes.py
@@ -280,6 +280,15 @@ def preserve_neighbors(
                 repulsive_fraction = 1
 
         n_repulsive = int(repulsive_fraction * edges.shape[0])
+        n_choose_2 = int(n * (n - 1) / 2)
+        if n_repulsive > n_choose_2:
+            problem.LOGGER.info(
+                f"The number of repulsive edges requested ({n_repulsive}) "
+                f"is larger than the total number of edges ({n_choose_2}). "
+                f"Sampling at most ({n_choose_2}) edges ..."
+            )
+            n_repulsive = n_choose_2
+
         negative_edges = preprocess.sample_edges(
             n, n_repulsive, exclude=edges
         ).to(device)


### PR DESCRIPTION
This change updates `preprocess.data_matrix.k_nearest_neighbors` to handle duplicated rows in the data matrix; a warning will be logged if duplicated rows are present, since this is typically a symptom of a problem with the original data.

This change additionally fixes some small bugs in `preprocess.preprocess.sample_edges`.

Fixes #13