### PR TITLE
Add laplacian embedding recipe

### DIFF
--- a/pymde/__init__.py
+++ b/pymde/__init__.py
@@ -17,4 +17,9 @@ from pymde.experiment_utils import latexify, plot
 
 from pymde.functions import losses, penalties
 
-from pymde.recipes import preserve_distances, preserve_neighbors
+from pymde.quadratic import pca
+from pymde.recipes import (
+    laplacian_embedding,
+    preserve_distances,
+    preserve_neighbors,
+)

--- a/pymde/datasets.py
+++ b/pymde/datasets.py
@@ -164,7 +164,7 @@ def MNIST(root="./", download=True) -> Dataset:
             download=False,
         )
 
-        images = torch.cat([mnist_train.data, mnist_test.data])
+        images = torch.cat([mnist_train.data, mnist_test.data]).float()
         digits = torch.cat([mnist_train.targets, mnist_test.targets])
         attributes = {"digits": digits}
         return Dataset(

--- a/pymde/recipes.py
+++ b/pymde/recipes.py
@@ -330,3 +330,59 @@ def preserve_neighbors(
             dtype=mde._X_init.dtype,
         )
     return mde
+
+
+def laplacian_embedding(
+    data,
+    embedding_dim=2,
+    n_neighbors=None,
+    max_distance=None,
+    init="quadratic",
+    device="cpu",
+    verbose=False,
+) -> problem.MDE:
+    """Constructs an MDE problem for computing a Laplacian emedding.
+
+    The embedding preserves the nearest neighbors of each item, using
+    quadratic distortion functions and a standardization constraint.
+
+    Arguments
+    ---------
+    data: {torch.Tensor, numpy.ndarray, scipy.sparse matrix}(
+            shape=(n_items, n_features)) or pymde.Graph
+        The original data, a data matrix or a graph. Neighbors are
+        computed using Euclidean distance if the data is a matrix,
+        or the shortest-path metric if the data is a graph.
+    embedding_dim: int
+        The embedding dimension. Use 2 or 3 for visualization.
+    n_neighbors: int (optional)
+        The number of nearest neighbors to compute for each row (item) of
+        ``data``. A sensible value is chosen by default, depending on the
+        number of items.
+    max_distance: float (optional)
+        If not None, neighborhoods are restricted to have a radius
+        no greater than ``max_distance``.
+    init: str
+        Initialization strategy; 'quadratic' or 'random'. If the quadratic
+        initialization takes too much time, try a random initialization.
+    device: str (optional)
+        Device for the embedding (eg, 'cpu', 'cuda').
+    verbose: bool
+        If ``True``, print verbose output.
+
+    Returns
+    -------
+    pymde.MDE
+        A ``pymde.MDE`` object, based on the original data.
+    """
+    return preserve_neighbors(
+        data,
+        embedding_dim=embedding_dim,
+        attractive_penalty=penalties.Quadratic,
+        repulsive_penalty=None,
+        n_neighbors=n_neighbors,
+        max_distance=max_distance,
+        init=init,
+        device=device,
+        verbose=verbose,
+    )

--- a/pymde/test_recipes.py
+++ b/pymde/test_recipes.py
@@ -1,6 +1,10 @@
 import numpy as np
+import torch
 
 from pymde import preprocess
+from pymde import recipes
+from pymde import util
+from pymde.functions import penalties
 import pymde.testing as testing
 
 
@@ -18,4 +22,32 @@ def test_k_nearest_neighbors():
     edges = graph.edges.cpu().numpy()
     # 2 if i and j are neighbors of each other,
     # 1 if i is neighbor of j but not vice versa
-    testing.assert_allclose(np.array([1., 1., 2., 2., 2.]), graph.weights)
+    testing.assert_allclose(np.array([1.0, 1.0, 2.0, 2.0, 2.0]), graph.weights)
+
+
+@testing.cpu_and_cuda
+def test_laplacian_embedding(device):
+    np.random.seed(0)
+    torch.manual_seed(0)
+    data_matrix = torch.randn(100, 10)
+
+    np.random.seed(0)
+    torch.manual_seed(0)
+    laplacian_emb = recipes.laplacian_embedding(
+        data_matrix, device=device
+    ).embed()
+
+    np.random.seed(0)
+    torch.manual_seed(0)
+    also_laplacian = recipes.preserve_neighbors(
+        data_matrix,
+        attractive_penalty=penalties.Quadratic,
+        repulsive_penalty=None,
+        device=device,
+    ).embed()
+
+    also_laplacian = util.align(source=also_laplacian, target=laplacian_emb)
+
+    testing.assert_allclose(
+        laplacian_emb.cpu().numpy(), also_laplacian.cpu().numpy()
+    )


### PR DESCRIPTION
Add a simple function that returns an MDE problem for making a
Laplacian embedding.

Bring `pca` to the top-level module.