### PR TITLE
minimum torch version to 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ PyMDE has the following requirements:
 * Python >= 3.7
 * numpy >= 1.17.5
 * scipy
-* torch
+* torch >= 1.7.1
 * torchvision
 * pynndescent
 * requests

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "numpy >= 1.17.5",
         "pynndescent",
         "scipy",
-        "torch",
+        "torch >= 1.7.1",
         "torchvision",
         # torchvision requires requests but does not list it as a dependency
         "requests",  


### PR DESCRIPTION
Some parts of the codebase use recent features of PyTorch. PyMDE has not been tested on torch < 1.7.1.