### PR TITLE
limit memory usage in _remove_anchor_anchor_edges

### DIFF
--- a/pymde/recipes.py
+++ b/pymde/recipes.py
@@ -12,20 +12,90 @@ from pymde.functions import penalties, losses
 from pymde import preprocess
 
 
-def _remove_anchor_anchor_edges(edges, data, anchors):
-    # exclude edges in which both items are anchors, since these
-    # items are already pinned in place by the anchor constraint
-    #
-    # TODO(akshayka): handle edge case in which every item is anchored,
-    # in which case the edge list will be empty after this exclusion
-    neither_anchors_mask = ~(
-        (edges[:, 0][..., None] == anchors).any(-1)
-        * (edges[:, 1][..., None] == anchors).any(-1)
-    )
+def _remove_anchor_anchor_edges(edges, data, anchors, opt=None, blk=1e8):
+    """
+    Exclude edges in which both items are anchors, since these
+    items are already pinned in place by the anchor constraint
+
+    TODO(akshayka): handle edge case in which every item is anchored,
+    in which case the edge list will be empty after this exclusion
+    
+    Arguments
+    ---------
+    edges:       edge list N x 2
+    data:        data to filter  N x ?
+    anchors:     remove anchor-to-anchor edges from edges[] and data[]
+    tuning parameters [optional, for fine-tuning the heuristics]
+      opt:       [None=automatic opt & blk] which implementation?
+      blk:       loop-blocking heuristic mem limit
+
+    `edges` and `data` can be torch or numpy arrays
+
+    Returns
+    -------
+    filtered versions of edges & data
+    """
+    na = anchors.shape[0]
+    if na <= 0:
+        return edges, data
+    blk = int(blk)
+    ne = edges.shape[0]
+    ea = ne * na # torch uses "ea" bytes of tmp mem for opt==0 (maybe too large)
+
+    if opt is None: # set both opt and blk according to simple heuristic
+        opt = 0
+        blk = int(1e8)
+        if ea > blk: # opt=0 is a possibility
+            opt = 1  # fall-back to 3
+            if ne>=150000:
+                blk = 262144
+
+    if opt == 0 and ea < blk:
+        neither_anchors_mask = ~(
+            (edges[:, 0][..., None] == anchors).any(-1)
+            * (edges[:, 1][..., None] == anchors).any(-1)
+        )
+
+    elif opt==1 and na < blk: # no need to block anchor-loop
+        #astep=na
+        estep=int(blk/na)
+        assert(estep > 0)
+        
+        msk0 = torch.zeros(ne, dtype=torch.bool)
+        msk1 = torch.zeros(ne, dtype=torch.bool)
+        e = 0
+        while e < ne:
+            ehi = e+estep if e+estep < ne else ne
+            msk0[e:ehi] |= (edges[e:ehi,0][...,None] == anchors).any(-1)
+            msk1[e:ehi] |= (edges[e:ehi,1][...,None] == anchors).any(-1)
+            e += estep
+        neither_anchors_mask = ~(msk0 & msk1) # neither
+
+    else: # o.w block both edge and anchor loops
+        astep=min(na,blk)
+        estep=int(blk/astep)
+        assert(astep > 0)
+        assert(estep > 0)
+        
+        msk0 = torch.zeros(ne, dtype=torch.bool)
+        msk1 = torch.zeros(ne, dtype=torch.bool)
+        e = 0
+        while e < ne:
+            ehi = e+estep if e+estep < ne else ne
+            e0 = edges[e:ehi,0][...,None]
+            e1 = edges[e:ehi,1][...,None]
+            a = 0
+            while a < na:
+                ahi = a+astep if a+astep < na else na
+                msk0[e:ehi] |= (e0 == anchors[a:ahi]).any(-1)
+                msk1[e:ehi] |= (e1 == anchors[a:ahi]).any(-1)
+                a += astep
+            e += estep
+        neither_anchors_mask = ~(msk0 & msk1) # neither
+
     edges = edges[neither_anchors_mask]
     data = data[neither_anchors_mask]
     return edges, data
-
 
 def preserve_distances(
     data,


### PR DESCRIPTION
On a small laptop, the MNIST anchor constraint notebook failed to run,
because it could not allocate some 20+ Gb of memory while removing
anchor anchor edges.

The temporary memory allocated by the short'n'sweet fast original is
"number of edges * number of anchors" bytes.

This PR blocks loops to limit memory usage to some reasonably small default.

I can supply a separate timing measurement code in case you want to adjust
the "reasonable heuristic" defaults I found to be OK.