### PR TITLE
build.yaml: cibuildwheel -> 2.3.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.8.0
+          python -m pip install cibuildwheel==2.3.0
 
       - name: Build wheels
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp37* cp38* cp39*"
+          CIBW_SKIP: "*musllinux*"
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
cibuildwheel 2.3.0 defaults to manylinux2014, which might help with the failing ubuntu deploy (which fails b/c scipy 1.7.3 does not have a suitable manylinux2010 wheel)