### PR TITLE
Build Fixes: Build arm64 wheels for macos, more robust build isolation for numpy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |
@@ -25,16 +25,12 @@ jobs:
           pip install flake8 pytest
           pip install -r requirements.txt
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==2.3.0
-
       - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
+				uses: pypa/cibuildwheel@v2.11.2
         env:
-          CIBW_BUILD: "cp37* cp38* cp39*"
+          CIBW_BUILD: "cp38* cp39* cp310* cp311*"
           CIBW_SKIP: "*musllinux*"
+          CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v2
         with:
@@ -49,7 +45,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: "cp38* cp39* cp310* cp311*"
-          CIBW_SKIP: "-win32 *-manylinux_i686 *musllinux*"
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
           CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: "cp38* cp39* cp310* cp311*"
-          CIBW_SKIP: "*musllinux*"
+          CIBW_SKIP: "-win32 *-manylinux_i686 *musllinux*"
           CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Build wheels
-				uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: "cp38* cp39* cp310* cp311*"
           CIBW_SKIP: "*musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,45 @@
 [build-system]
 requires = [
-  "numpy==1.17.5; python_version=='3.7'",
-  "numpy==1.17.5; python_version=='3.8'",
-  "numpy>=1.19,<1.20; python_version=='3.9'",
+  # NumPy dependencies copied from SciPy:
+  # https://github.com/scipy/scipy/blob/3df34d96123678e4b1b03aba83b84d8ff08817e5/pyproject.toml
+  # NumPy dependencies - to update these, sync from
+  # https://github.com/scipy/oldest-supported-numpy/, and then
+  # update minimum version to match our install_requires min version
+  # ----------------------------------------------------------------
+
+  # now matches minimum supported version, keep here as separate requirement
+  # to be able to sync more easily with oldest-supported-numpy
+  "numpy==1.19.5; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",
+
+  # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
+  # (first version with arm64 wheels available)
+  "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
+  "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
+
+  # loongarch64 requires numpy>=1.22.0
+  "numpy==1.22.0; platform_machine=='loongarch64'",
+
+  # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
+  # built with vc142. 1.22.3 is the first version that has 32-bit Windows
+  # wheels *and* was built with vc141. So use that:
+  "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
+
+  # default numpy requirements
+  "numpy==1.19.5; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
+  "numpy==1.19.5; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
+  # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
+  # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6
+  # (see oldest-supported-numpy issues gh-28 and gh-45)
+  "numpy==1.21.6; python_version=='3.10' and (platform_system!='Windows' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
+  "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+
+  # For Python versions which aren't yet officially supported,
+  # we specify an unpinned NumPy which allows source distributions
+  # to be used and allows wheels to be used as soon as they
+  # become available.
+  "numpy; python_version>='3.12'",
+  "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
+
   "scipy >= 1.6",
   "setuptools",
   "wheel",


### PR DESCRIPTION
- arm64 wheels for macos through cibuildwheel's cross compilation
- choose numpy version during build based on platform, in addition to python version (copied from SciPy's pyproject.toml)